### PR TITLE
Add support for storage

### DIFF
--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -12,7 +12,7 @@ from pymodbus.payload import BinaryPayloadDecoder
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL
+from homeassistant.const import CONF_NAME, CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.core import callback
 from homeassistant.helpers.event import async_track_time_interval
@@ -201,28 +201,28 @@ class SolaredgeModbusHub:
         )
 
     def read_modbus_data_inverter_stub(self):
-        self.data["accurrent"] = 1
-        self.data["accurrenta"] = 1
-        self.data["accurrentb"] = 1
-        self.data["accurrentc"] = 1
-        self.data["acvoltageab"] = 1
-        self.data["acvoltagebc"] = 1
-        self.data["acvoltageca"] = 1
-        self.data["acvoltagean"] = 1
-        self.data["acvoltagebn"] = 1
-        self.data["acvoltagecn"] = 1
-        self.data["acpower"] = 1
-        self.data["acfreq"] = 1
-        self.data["acva"] = 1
-        self.data["acvar"] = 1
-        self.data["acpf"] = 1
-        self.data["acenergy"] = 1
-        self.data["dccurrent"] = 1
-        self.data["dcvoltage"] = 1
-        self.data["dcpower"] = 1
-        self.data["tempsink"] = 1
-        self.data["status"] = 1
-        self.data["statusvendor"] = 1
+        self.data["accurrent"] = STATE_UNKNOWN
+        self.data["accurrenta"] = STATE_UNKNOWN
+        self.data["accurrentb"] = STATE_UNKNOWN
+        self.data["accurrentc"] = STATE_UNKNOWN
+        self.data["acvoltageab"] = STATE_UNKNOWN
+        self.data["acvoltagebc"] = STATE_UNKNOWN
+        self.data["acvoltageca"] = STATE_UNKNOWN
+        self.data["acvoltagean"] = STATE_UNKNOWN
+        self.data["acvoltagebn"] = STATE_UNKNOWN
+        self.data["acvoltagecn"] = STATE_UNKNOWN
+        self.data["acpower"] = STATE_UNKNOWN
+        self.data["acfreq"] = STATE_UNKNOWN
+        self.data["acva"] = STATE_UNKNOWN
+        self.data["acvar"] = STATE_UNKNOWN
+        self.data["acpf"] = STATE_UNKNOWN
+        self.data["acenergy"] = STATE_UNKNOWN
+        self.data["dccurrent"] = STATE_UNKNOWN
+        self.data["dcvoltage"] = STATE_UNKNOWN
+        self.data["dcpower"] = STATE_UNKNOWN
+        self.data["tempsink"] = STATE_UNKNOWN
+        self.data["status"] = STATE_UNKNOWN
+        self.data["statusvendor"] = STATE_UNKNOWN
 
         return True
 
@@ -236,81 +236,81 @@ class SolaredgeModbusHub:
         return self.read_modbus_data_meter_stub("m3_")
 
     def read_modbus_data_meter_stub(self, meter_prefix):
-        self.data[meter_prefix + "accurrent"] = 2
-        self.data[meter_prefix + "accurrenta"] = 2
-        self.data[meter_prefix + "accurrentb"] = 2
-        self.data[meter_prefix + "accurrentc"] = 2
+        self.data[meter_prefix + "accurrent"] = STATE_UNKNOWN
+        self.data[meter_prefix + "accurrenta"] = STATE_UNKNOWN
+        self.data[meter_prefix + "accurrentb"] = STATE_UNKNOWN
+        self.data[meter_prefix + "accurrentc"] = STATE_UNKNOWN
 
-        self.data[meter_prefix + "acvoltageln"] = 2
-        self.data[meter_prefix + "acvoltagean"] = 2
-        self.data[meter_prefix + "acvoltagebn"] = 2
-        self.data[meter_prefix + "acvoltagecn"] = 2
-        self.data[meter_prefix + "acvoltagell"] = 2
-        self.data[meter_prefix + "acvoltageab"] = 2
-        self.data[meter_prefix + "acvoltagebc"] = 2
-        self.data[meter_prefix + "acvoltageca"] = 2
+        self.data[meter_prefix + "acvoltageln"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acvoltagean"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acvoltagebn"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acvoltagecn"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acvoltagell"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acvoltageab"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acvoltagebc"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acvoltageca"] = STATE_UNKNOWN
 
-        self.data[meter_prefix + "acfreq"] = 2
+        self.data[meter_prefix + "acfreq"] = STATE_UNKNOWN
 
-        self.data[meter_prefix + "acpower"] = 2
-        self.data[meter_prefix + "acpowera"] = 2
-        self.data[meter_prefix + "acpowerb"] = 2
-        self.data[meter_prefix + "acpowerc"] = 2
+        self.data[meter_prefix + "acpower"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acpowera"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acpowerb"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acpowerc"] = STATE_UNKNOWN
 
-        self.data[meter_prefix + "acva"] = 2
-        self.data[meter_prefix + "acvaa"] = 2
-        self.data[meter_prefix + "acvab"] = 2
-        self.data[meter_prefix + "acvac"] = 2
+        self.data[meter_prefix + "acva"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acvaa"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acvab"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acvac"] = STATE_UNKNOWN
 
-        self.data[meter_prefix + "acvar"] = 2
-        self.data[meter_prefix + "acvara"] = 2
-        self.data[meter_prefix + "acvarb"] = 2
-        self.data[meter_prefix + "acvarc"] = 2
+        self.data[meter_prefix + "acvar"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acvara"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acvarb"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acvarc"] = STATE_UNKNOWN
 
-        self.data[meter_prefix + "acpf"] = 2
-        self.data[meter_prefix + "acpfa"] = 2
-        self.data[meter_prefix + "acpfb"] = 2
-        self.data[meter_prefix + "acpfc"] = 2
+        self.data[meter_prefix + "acpf"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acpfa"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acpfb"] = STATE_UNKNOWN
+        self.data[meter_prefix + "acpfc"] = STATE_UNKNOWN
 
-        self.data[meter_prefix + "exported"] = 2
-        self.data[meter_prefix + "exporteda"] = 2
-        self.data[meter_prefix + "exportedb"] = 2
-        self.data[meter_prefix + "exportedc"] = 2
+        self.data[meter_prefix + "exported"] = STATE_UNKNOWN
+        self.data[meter_prefix + "exporteda"] = STATE_UNKNOWN
+        self.data[meter_prefix + "exportedb"] = STATE_UNKNOWN
+        self.data[meter_prefix + "exportedc"] = STATE_UNKNOWN
 
-        self.data[meter_prefix + "imported"] = 2
-        self.data[meter_prefix + "importeda"] = 2
-        self.data[meter_prefix + "importedb"] = 2
-        self.data[meter_prefix + "importedc"] = 2
+        self.data[meter_prefix + "imported"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importeda"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importedb"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importedc"] = STATE_UNKNOWN
 
-        self.data[meter_prefix + "exportedva"] = 2
-        self.data[meter_prefix + "exportedvaa"] = 2
-        self.data[meter_prefix + "exportedvab"] = 2
-        self.data[meter_prefix + "exportedvac"] = 2
+        self.data[meter_prefix + "exportedva"] = STATE_UNKNOWN
+        self.data[meter_prefix + "exportedvaa"] = STATE_UNKNOWN
+        self.data[meter_prefix + "exportedvab"] = STATE_UNKNOWN
+        self.data[meter_prefix + "exportedvac"] = STATE_UNKNOWN
 
-        self.data[meter_prefix + "importedva"] = 2
-        self.data[meter_prefix + "importedvaa"] = 2
-        self.data[meter_prefix + "importedvab"] = 2
-        self.data[meter_prefix + "importedvac"] = 2
+        self.data[meter_prefix + "importedva"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importedvaa"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importedvab"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importedvac"] = STATE_UNKNOWN
 
-        self.data[meter_prefix + "importvarhq1"] = 2
-        self.data[meter_prefix + "importvarhq1a"] = 2
-        self.data[meter_prefix + "importvarhq1b"] = 2
-        self.data[meter_prefix + "importvarhq1c"] = 2
+        self.data[meter_prefix + "importvarhq1"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importvarhq1a"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importvarhq1b"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importvarhq1c"] = STATE_UNKNOWN
 
-        self.data[meter_prefix + "importvarhq2"] = 2
-        self.data[meter_prefix + "importvarhq2a"] = 2
-        self.data[meter_prefix + "importvarhq2b"] = 2
-        self.data[meter_prefix + "importvarhq2c"] = 2
+        self.data[meter_prefix + "importvarhq2"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importvarhq2a"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importvarhq2b"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importvarhq2c"] = STATE_UNKNOWN
 
-        self.data[meter_prefix + "importvarhq3"] = 2
-        self.data[meter_prefix + "importvarhq3a"] = 2
-        self.data[meter_prefix + "importvarhq3b"] = 2
-        self.data[meter_prefix + "importvarhq3c"] = 2
+        self.data[meter_prefix + "importvarhq3"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importvarhq3a"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importvarhq3b"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importvarhq3c"] = STATE_UNKNOWN
 
-        self.data[meter_prefix + "importvarhq4"] = 2
-        self.data[meter_prefix + "importvarhq4a"] = 2
-        self.data[meter_prefix + "importvarhq4b"] = 2
-        self.data[meter_prefix + "importvarhq4c"] = 2
+        self.data[meter_prefix + "importvarhq4"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importvarhq4a"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importvarhq4b"] = STATE_UNKNOWN
+        self.data[meter_prefix + "importvarhq4c"] = STATE_UNKNOWN
 
         return True
 

--- a/custom_components/solaredge_modbus/config_flow.py
+++ b/custom_components/solaredge_modbus/config_flow.py
@@ -13,9 +13,13 @@ from .const import (
     CONF_READ_METER1,
     CONF_READ_METER2,
     CONF_READ_METER3,
+    CONF_READ_BATTERY1,
+    CONF_READ_BATTERY2,
     DEFAULT_READ_METER1,
     DEFAULT_READ_METER2,
     DEFAULT_READ_METER3,
+    DEFAULT_READ_BATTERY1,
+    DEFAULT_READ_BATTERY2
 )
 from homeassistant.core import HomeAssistant, callback
 
@@ -27,6 +31,8 @@ DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_READ_METER1, default=DEFAULT_READ_METER1): bool,
         vol.Optional(CONF_READ_METER2, default=DEFAULT_READ_METER2): bool,
         vol.Optional(CONF_READ_METER3, default=DEFAULT_READ_METER3): bool,
+        vol.Optional(CONF_READ_BATTERY1, default=DEFAULT_READ_BATTERY1): bool,
+        vol.Optional(CONF_READ_BATTERY2, default=DEFAULT_READ_BATTERY2): bool,
         vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): int,
     }
 )

--- a/custom_components/solaredge_modbus/const.py
+++ b/custom_components/solaredge_modbus/const.py
@@ -5,12 +5,16 @@ DEFAULT_PORT = 1502
 DEFAULT_READ_METER1 = False
 DEFAULT_READ_METER2 = False
 DEFAULT_READ_METER3 = False
+DEFAULT_READ_BATTERY1 = False
+DEFAULT_READ_BATTERY2 = False
 CONF_SOLAREDGE_HUB = "solaredge_hub"
 ATTR_STATUS_DESCRIPTION = "status_description"
 ATTR_MANUFACTURER = "Solaredge"
 CONF_READ_METER1 = "read_meter_1"
 CONF_READ_METER2 = "read_meter_2"
 CONF_READ_METER3 = "read_meter_3"
+CONF_READ_BATTERY1 = "read_battery_1"
+CONF_READ_BATTERY2 = "read_battery_2"
 
 SENSOR_TYPES = {
     "AC_Current": ["AC Current", "accurrent", "A", "mdi:current-ac"],
@@ -230,6 +234,36 @@ METER3_SENSOR_TYPES = {
     "M3_IMPORT_VARH_Q4_C": ["M3 IMPORT VARH Q4 C", "m3_importvarhq4c", "VARh", None],
 }
 
+BATTERY1_SENSOR_TYPES = {
+    "BATTERY1_Temp_avg": ["Battery1 Temp Average", "battery1_temp_avg", "°C", None],
+    "BATTERY1_Temp_max": ["Battery1 Temp Maximum", "battery1_temp_max", "°C", None],
+    "BATTERY1_Voltage": ["Battery1 Voltage", "battery1_voltage", "V", None],
+    "BATTERY1_Current": ["Battery1 Current", "battery1_current", "A", None],
+    "BATTERY1_Power": ["Battery1 Power", "battery1_power", "W", "mdi:battery-charging-100"],
+    "BATTERY1_Discharged": ["Battery1 Discharged", "battery1_energy_discharged", "kWh", None],
+    "BATTERY1_Charged": ["Battery1 Charged", "battery1_energy_charged", "kWh", None],
+    "BATTERY1_Size_max": ["Battery1 Size Max", "battery1_size_max", "kWh", None],
+    "BATTERY1_Size_available": ["Battery1 Size Available", "battery1_size_available", "kWh", None],
+    "BATTERY1_SOH": ["Battery1 State of Health", "battery1_state_of_health", "%", None],
+    "BATTERY1_SOC": ["Battery1 State of Charge", "battery1_state_of_charge", "%", "mdi:battery-high"],
+    "BATTERY1_Status": ["Battery1 Status", "battery1_status", None, None],
+}
+
+BATTERY2_SENSOR_TYPES = {
+    "BATTERY2_Temp_avg": ["Battery2 Temp Average", "battery2_temp_avg", "°C", None],
+    "BATTERY2_Temp_max": ["Battery2 Temp Maximum", "battery2_temp_max", "°C", None],
+    "BATTERY2_Voltage": ["Battery2 Voltage", "battery2_voltage", "V", None],
+    "BATTERY2_Current": ["Battery2 Current", "battery2_current", "A", None],
+    "BATTERY2_Power": ["Battery2 Power", "battery2_power", "W", "mdi:battery-charging-100"],
+    "BATTERY2_Discharged": ["Battery2 Discharged", "battery2_energy_discharged", "kWh", None],
+    "BATTERY2_Charged": ["Battery2 Charged", "battery2_energy_charged", "kWh", None],
+    "BATTERY2_Size_max": ["Battery2 Size Max", "battery2_size_max", "kWh", None],
+    "BATTERY2_Size_available": ["Battery2 Size Available", "battery2_size_available", "kWh", None],
+    "BATTERY2_SOH": ["Battery2 State of Health", "battery2_state_of_health", "%", None],
+    "BATTERY2_SOC": ["Battery2 State of Charge", "battery2_state_of_charge", "%", "mdi:battery-high"],
+    "BATTERY2_Status": ["Battery2 Status", "battery2_status", None, None],
+}
+
 DEVICE_STATUSSES = {
     1: "Off",
     2: "Sleeping (auto-shutdown) – Night mode",
@@ -239,4 +273,12 @@ DEVICE_STATUSSES = {
     6: "Shutting down",
     7: "Fault",
     8: "Maintenance/setup",
+}
+
+BATTERY_STATUSSES = {
+    1: "Off",
+    3: "Charging",
+    4: "Discharging",
+    6: "Idle",
+    10: "Sleep"
 }

--- a/custom_components/solaredge_modbus/sensor.py
+++ b/custom_components/solaredge_modbus/sensor.py
@@ -5,9 +5,12 @@ from .const import (
     METER1_SENSOR_TYPES,
     METER2_SENSOR_TYPES,
     METER3_SENSOR_TYPES,
+    BATTERY1_SENSOR_TYPES,
+    BATTERY2_SENSOR_TYPES,
     DOMAIN,
     ATTR_STATUS_DESCRIPTION,
     DEVICE_STATUSSES,
+    BATTERY_STATUSSES,
     ATTR_MANUFACTURER,
 )
 from datetime import datetime
@@ -90,6 +93,32 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 meter_sensor_info[1],
                 meter_sensor_info[2],
                 meter_sensor_info[3],
+            )
+            entities.append(sensor)
+
+    if hub.read_battery1 == True:
+        for sensor_info in BATTERY1_SENSOR_TYPES.values():
+            sensor = SolarEdgeSensor(
+                hub_name,
+                hub,
+                device_info,
+                sensor_info[0],
+                sensor_info[1],
+                sensor_info[2],
+                sensor_info[3],
+            )
+            entities.append(sensor)
+
+    if hub.read_battery2 == True:
+        for sensor_info in BATTERY2_SENSOR_TYPES.values():
+            sensor = SolarEdgeSensor(
+                hub_name,
+                hub,
+                device_info,
+                sensor_info[0],
+                sensor_info[1],
+                sensor_info[2],
+                sensor_info[3],
             )
             entities.append(sensor)
 

--- a/custom_components/solaredge_modbus/strings.json
+++ b/custom_components/solaredge_modbus/strings.json
@@ -11,6 +11,8 @@
           "read_meter_1": "Read meter 1 data (only for meter models)",
           "read_meter_2": "Read meter 2 data (only for meter models)",
           "read_meter_3": "Read meter 3 data (only for meter models)",
+          "read_battery_1": "Read battery 1 data (only when equipped)",
+          "read_battery_2": "Read battery 2 data (only when equipped)",
           "scan_interval": "The polling frequentie of the modbus registers in seconds"
         }
       }

--- a/custom_components/solaredge_modbus/translations/en.json
+++ b/custom_components/solaredge_modbus/translations/en.json
@@ -11,6 +11,8 @@
           "read_meter_1": "Read meter 1 data (only for meter models)",
           "read_meter_2": "Read meter 2 data (only for meter models)",
           "read_meter_3": "Read meter 3 data (only for meter models)",
+          "read_battery_1": "Read battery 1 data (only when equipped)",
+          "read_battery_2": "Read battery 2 data (only when equipped)",
           "scan_interval": "The polling frequentie of the modbus registers in seconds"
         }
       }

--- a/custom_components/solaredge_modbus/translations/nb.json
+++ b/custom_components/solaredge_modbus/translations/nb.json
@@ -11,6 +11,8 @@
           "read_meter_1": "Les måler 1-data (bare for målermodeller)",
           "read_meter_2": "Les måler 2-data (bare for målermodeller)",
           "read_meter_3": "Les måler 3-data (bare for målermodeller)",
+          "read_battery_1": "Les batteri 1 data (bare når den er utstyrt)",
+          "read_battery_2": "Les batteri 2 data (bare når den er utstyrt)",
           "scan_interval": "Avstemningsfrekvensen til modbus registreres på få sekunder"
         }
       }

--- a/custom_components/solaredge_modbus/translations/nl.json
+++ b/custom_components/solaredge_modbus/translations/nl.json
@@ -11,6 +11,8 @@
           "read_meter_1": "Lees meter 1 data (enkel voor voor meter modellen)",
           "read_meter_2": "Lees meter 2 data (enkel voor voor meter modellen)",
           "read_meter_3": "Lees meter 3 data (enkel voor voor meter modellen)",
+          "read_battery_1": "Lees accu 1 data (alleen indien uitgerust)",
+          "read_battery_2": "Lees accu 2 data (alleen indien uitgerust)",
           "scan_interval": "De polling-frequentie van de modbus registratie in seconden"
         }
       }


### PR DESCRIPTION
Add support for reading the modbus registers for storage status.
This works with my Solaredge HD Wave SE3680 inverter with LG RESU 7kWh battery.
The sensors give access to the battery power and energy flows which can be used for Home Assistants energy dashboard.
Much inspiration for the code taken from
https://github.com/mkrasselt1/solaredge-modbus-hass/commit/58adaffbcfced20f966d5edf38b7d8c401000c8d

Additionally set all sensors to "STATE_UNKNOWN" instead of a numeric value, such that cumulative sensors like "acenergy" do not go backwards and trigger a reset of home assistants internal value.
