### PR TITLE
Add export control

### DIFF
--- a/custom_components/solaredge_modbus/const.py
+++ b/custom_components/solaredge_modbus/const.py
@@ -283,6 +283,18 @@ BATTERY_STATUSSES = {
     10: "Sleep"
 }
 
+EXPORT_CONTROL_MODE = {
+    0: "Disabled",
+    1: "Direct Export Limitation",
+    2: "Indirect Export Limitation",
+    4: "Production Limitation"
+}
+
+EXPORT_CONTROL_LIMIT_MODE = {
+    0: "Total",
+    1: "Per phase"
+}
+
 STOREDGE_CONTROL_MODE = {
     0: "Disabled",
     1: "Maximize Self Consumption",
@@ -307,6 +319,15 @@ STOREDGE_CHARGE_DISCHARGE_MODE = {
     5: "Discharge to match load",
     7: "Maximize self consumption",
 }
+
+EXPORT_CONTROL_SELECT_TYPES = [
+    ["Export control mode", "export_control_mode", 0xE000, EXPORT_CONTROL_MODE],
+    ["Export control limit mode", "export_control_limit_mode", 0xE001, EXPORT_CONTROL_LIMIT_MODE],
+]
+
+EXPORT_CONTROL_NUMBER_TYPES = [
+    ["Export control site limit", "export_control_site_limit", 0xE002, "f", {"min": 0, "max": 10000, "unit": "W"}],
+]
 
 STORAGE_SELECT_TYPES = [
     ["Storage Control Mode", "storage_contol_mode", 0xE004, STOREDGE_CONTROL_MODE],

--- a/custom_components/solaredge_modbus/number.py
+++ b/custom_components/solaredge_modbus/number.py
@@ -4,6 +4,7 @@ from typing import Optional, Dict, Any
 from .const import (
     DOMAIN,
     ATTR_MANUFACTURER,
+    EXPORT_CONTROL_NUMBER_TYPES,
     STORAGE_NUMBER_TYPES,
 )
 
@@ -32,7 +33,23 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 
     entities = []
 
-    if hub.read_battery1 == True or hub.read_battery2 == True:
+    # If a meter is available add export control
+    if hub.has_meter:
+        for number_info in EXPORT_CONTROL_NUMBER_TYPES:
+            number = SolarEdgeNumber(
+                hub_name,
+                hub,
+                device_info,
+                number_info[0],
+                number_info[1],
+                number_info[2],
+                number_info[3],
+                number_info[4],
+            )
+            entities.append(number)
+
+    # If a battery is available add storage control
+    if hub.has_battery:
         for number_info in STORAGE_NUMBER_TYPES:
             number = SolarEdgeNumber(
                 hub_name,

--- a/custom_components/solaredge_modbus/select.py
+++ b/custom_components/solaredge_modbus/select.py
@@ -4,6 +4,7 @@ from typing import Optional, Dict, Any
 from .const import (
     DOMAIN,
     ATTR_MANUFACTURER,
+    EXPORT_CONTROL_SELECT_TYPES,
     STORAGE_SELECT_TYPES,
 )
 
@@ -29,7 +30,22 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 
     entities = []
 
-    if hub.read_battery1 == True or hub.read_battery2 == True:
+    # If a meter is available add export control
+    if hub.has_meter:
+        for select_info in EXPORT_CONTROL_SELECT_TYPES:
+            select = SolarEdgeSelect(
+                hub_name,
+                hub,
+                device_info,
+                select_info[0],
+                select_info[1],
+                select_info[2],
+                select_info[3],
+            )
+            entities.append(select)
+
+    # If a battery is available add storage control
+    if hub.has_battery:
         for select_info in STORAGE_SELECT_TYPES:
             select = SolarEdgeSelect(
                 hub_name,


### PR DESCRIPTION
The export control block allows control of how much power is exported
from the system to the grid. This may be useful, for example, to prevent
export if the export rate is negative.

As requested by @nerfherder in #38.