### PR TITLE
Override battery reported power to 0 when it is sleeping

### DIFF
--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -758,6 +758,7 @@ class SolaredgeModbusHub:
             if not battery_status in [3,4,6]:
                 self.data[battery_prefix + 'voltage'] = 0
                 self.data[battery_prefix + 'current'] = 0
+                self.data[battery_prefix + 'power'] = 0
 
             if battery_status in BATTERY_STATUSSES:
                 self.data[battery_prefix + 'status'] = BATTERY_STATUSSES[battery_status]


### PR DESCRIPTION
As well as current and voltage having bogus values when the battery is
asleep, some batteries seem to report bogus power. Zero this as well.

Fixes #45.