### PR TITLE
Make all non-energy sensors state class measurement

### DIFF
--- a/custom_components/solaredge_modbus/sensor.py
+++ b/custom_components/solaredge_modbus/sensor.py
@@ -138,6 +138,7 @@ class SolarEdgeSensor(SensorEntity):
         self._unit_of_measurement = unit
         self._icon = icon
         self._device_info = device_info
+        self._attr_state_class = STATE_CLASS_MEASUREMENT
         if self._unit_of_measurement == ENERGY_KILO_WATT_HOUR:
             self._attr_state_class = STATE_CLASS_TOTAL_INCREASING
             self._attr_device_class = DEVICE_CLASS_ENERGY


### PR DESCRIPTION
We expose all sensors with units of kWh as state class total increasing and device class energy. In order for all of our other sensors to be usable as statistics, we just need to make them state class measurement.

Closes #51 