### PR TITLE
Remove validation of exported energy being > 0

### DIFF
--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -402,7 +402,7 @@ class SolaredgeModbusHub:
             importedc = decoder.decode_32bit_uint()
             energywsf = decoder.decode_16bit_int()
 
-            exported = validate(self.calculate_value(exported, energywsf), ">", 0)
+            exported = self.calculate_value(exported, energywsf)
             exporteda = self.calculate_value(exporteda, energywsf)
             exportedb = self.calculate_value(exportedb, energywsf)
             exportedc = self.calculate_value(exportedc, energywsf)


### PR DESCRIPTION
If the system is configured to limit export to 0, this meter reading can
legitimately be 0.

Signed-off-by: Matt Redfearn <matt.redfearn@gmail.com>