### PR TITLE
make timeout dependent on scan interval

### DIFF
--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -169,7 +169,7 @@ class SolaredgeModbusHub:
     ):
         """Initialize the Modbus hub."""
         self._hass = hass
-        self._client = ModbusTcpClient(host=host, port=port)
+        self._client = ModbusTcpClient(host=host, port=port, timeout=(scan_interval - 1))
         self._lock = threading.Lock()
         self._name = name
         self._address = address


### PR DESCRIPTION
In order to prevent an unresponsive UI in Home Assistant in case of connectivity issues of the modbus server, the client now uses not the default timeout but a timeout dependent on the selected scan interval.

This fixes #100