### PR TITLE
Make MAX_EXPORT_CONTROL_SITE_LIMIT configurable

### DIFF
--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -41,6 +41,8 @@ from .const import (
     STOREDGE_CONTROL_MODE,
     STOREDGE_AC_CHARGE_POLICY,
     STOREDGE_CHARGE_DISCHARGE_MODE,
+    CONF_MAX_EXPORT_CONTROL_SITE_LIMIT,
+    DEFAULT_MAX_EXPORT_CONTROL_SITE_LIMIT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -61,6 +63,10 @@ SOLAREDGE_MODBUS_SCHEMA = vol.Schema(
         vol.Optional(CONF_READ_BATTERY2, default=DEFAULT_READ_BATTERY2): cv.boolean,
         vol.Optional(
             CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+        ): cv.positive_int,
+        vol.Optional(
+            CONF_MAX_EXPORT_CONTROL_SITE_LIMIT,
+            default=DEFAULT_MAX_EXPORT_CONTROL_SITE_LIMIT,
         ): cv.positive_int,
     }
 )
@@ -91,6 +97,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     read_meter3 = entry.data.get(CONF_READ_METER3, DEFAULT_READ_METER3)
     read_battery1 = entry.data.get(CONF_READ_BATTERY1, DEFAULT_READ_BATTERY1)
     read_battery2 = entry.data.get(CONF_READ_BATTERY2, DEFAULT_READ_BATTERY2)
+    max_export_control_site_limit = entry.data.get(
+        CONF_MAX_EXPORT_CONTROL_SITE_LIMIT, DEFAULT_MAX_EXPORT_CONTROL_SITE_LIMIT
+    )
 
     _LOGGER.debug("Setup %s.%s", DOMAIN, name)
 
@@ -107,6 +116,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         read_meter3,
         read_battery1,
         read_battery2,
+        max_export_control_site_limit,
     )
     """Register the hub."""
     hass.data[DOMAIN][name] = {"hub": hub}
@@ -181,6 +191,7 @@ class SolaredgeModbusHub:
         self.read_battery1 = read_battery1
         self.read_battery2 = read_battery2
         self._scan_interval = timedelta(seconds=scan_interval)
+        self.max_export_control_site_limit = max_export_control_site_limit
         self._unsub_interval_method = None
         self._sensors = []
         self.data = {}

--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -176,6 +176,7 @@ class SolaredgeModbusHub:
         read_meter3=DEFAULT_READ_METER3,
         read_battery1=DEFAULT_READ_BATTERY1,
         read_battery2=DEFAULT_READ_BATTERY2,
+        max_export_control_site_limit=DEFAULT_MAX_EXPORT_CONTROL_SITE_LIMIT
     ):
         """Initialize the Modbus hub."""
         self._hass = hass

--- a/custom_components/solaredge_modbus/config_flow.py
+++ b/custom_components/solaredge_modbus/config_flow.py
@@ -23,7 +23,9 @@ from .const import (
     DEFAULT_READ_METER2,
     DEFAULT_READ_METER3,
     DEFAULT_READ_BATTERY1,
-    DEFAULT_READ_BATTERY2
+    DEFAULT_READ_BATTERY2,
+    CONF_MAX_EXPORT_CONTROL_SITE_LIMIT,
+    DEFAULT_MAX_EXPORT_CONTROL_SITE_LIMIT
 )
 from homeassistant.core import HomeAssistant, callback
 
@@ -40,6 +42,7 @@ DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_READ_BATTERY1, default=DEFAULT_READ_BATTERY1): bool,
         vol.Optional(CONF_READ_BATTERY2, default=DEFAULT_READ_BATTERY2): bool,
         vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): int,
+        vol.Optional(CONF_MAX_EXPORT_CONTROL_SITE_LIMIT, default=DEFAULT_MAX_EXPORT_CONTROL_SITE_LIMIT): int,
     }
 )
 

--- a/custom_components/solaredge_modbus/const.py
+++ b/custom_components/solaredge_modbus/const.py
@@ -19,6 +19,8 @@ CONF_READ_METER2 = "read_meter_2"
 CONF_READ_METER3 = "read_meter_3"
 CONF_READ_BATTERY1 = "read_battery_1"
 CONF_READ_BATTERY2 = "read_battery_2"
+CONF_MAX_EXPORT_CONTROL_SITE_LIMIT = "max_export_control_site_limit"
+DEFAULT_MAX_EXPORT_CONTROL_SITE_LIMIT = 10000
 
 SENSOR_TYPES = {
     "AC_Current": ["AC Current", "accurrent", "A", "mdi:current-ac"],
@@ -330,7 +332,7 @@ EXPORT_CONTROL_SELECT_TYPES = [
 ]
 
 EXPORT_CONTROL_NUMBER_TYPES = [
-    ["Export control site limit", "export_control_site_limit", 0xE002, "f", {"min": 0, "max": 10000, "unit": "W"}],
+    ["Export control site limit", "export_control_site_limit", 0xE002, "f", {"min": 0, "max": DEFAULT_MAX_EXPORT_CONTROL_SITE_LIMIT, "unit": "W"}],
 ]
 
 ACTIVE_POWER_LIMIT_TYPE = ["Active Power Limit", "nominal_active_power_limit", 0xF001, "u16", {"min": 0, "max": 100, "unit": "%"}]

--- a/custom_components/solaredge_modbus/number.py
+++ b/custom_components/solaredge_modbus/number.py
@@ -59,7 +59,10 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                 number_info[1],
                 number_info[2],
                 number_info[3],
-                number_info[4],
+                dict(min=number_info[4]['min'],
+                     max=hub.max_export_control_site_limit,
+                     unit=number_info[4]['unit']
+                )
             )
             entities.append(number)
 


### PR DESCRIPTION
There are inverters with more than 10 kW power. I'm running 25 kW one and have changed the definition in const.py file manually to 25000. In my opinion this parameter should be configurable and should be redifned via config setup of this integration. Pls apply this PR after the integration of https://github.com/binsentsu/home-assistant-solaredge-modbus/pull/197

this PR adresses as well the issue https://github.com/binsentsu/home-assistant-solaredge-modbus/issues/186

thanks in advance