### PR TITLE
Replace deprecated magic numbers with EntityState enums

### DIFF
--- a/custom_components/solaredge_modbus/sensor.py
+++ b/custom_components/solaredge_modbus/sensor.py
@@ -18,16 +18,10 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.const import CONF_NAME, UnitOfEnergy, UnitOfPower
 from homeassistant.components.sensor import (
     PLATFORM_SCHEMA,
-    STATE_CLASS_MEASUREMENT,
     SensorEntity,
     SensorDeviceClass,
+    SensorStateClass
 )
-
-try: # backward-compatibility to 2021.8
-    from homeassistant.components.sensor import STATE_CLASS_TOTAL_INCREASING
-except ImportError:
-    from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT as STATE_CLASS_TOTAL_INCREASING
-
 
 from homeassistant.core import callback
 from homeassistant.util import dt as dt_util
@@ -139,11 +133,11 @@ class SolarEdgeSensor(SensorEntity):
         self._unit_of_measurement = unit
         self._icon = icon
         self._device_info = device_info
-        self._attr_state_class = STATE_CLASS_MEASUREMENT
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         if self._unit_of_measurement == UnitOfEnergy.KILO_WATT_HOUR :
-            self._attr_state_class = STATE_CLASS_TOTAL_INCREASING
+            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
             self._attr_device_class = SensorDeviceClass.ENERGY
-            if STATE_CLASS_TOTAL_INCREASING == STATE_CLASS_MEASUREMENT: # compatibility to 2021.8
+            if SensorStateClass.TOTAL_INCREASING == SensorStateClass.MEASUREMENT: # compatibility to 2021.8
                 self._attr_last_reset = dt_util.utc_from_timestamp(0)
         if self._unit_of_measurement == UnitOfPower.WATT :
             self._attr_device_class = SensorDeviceClass.POWER


### PR DESCRIPTION
A try to fix the 2025.01 deprecation issue as described in #216.

Please check carefully as it possibly removes some backwards compatabillity