### PR TITLE
Add missing max_export_control_site_limit string, improve

### DIFF
--- a/custom_components/solaredge_modbus/strings.json
+++ b/custom_components/solaredge_modbus/strings.json
@@ -16,7 +16,8 @@
           "read_battery_1": "Read battery 1 data (only when equipped)",
           "read_battery_2": "Read battery 2 data (only when equipped)",
           "read_battery_3": "Read battery 3 data (only when equipped)",
-          "scan_interval": "The polling frequency of the modbus registers in seconds"
+          "scan_interval": "The modbus registers polling interval [s]"
+          "max_export_control_site_limit": "The maximum export-control site-limit [W]"
         }
       }
     },

--- a/custom_components/solaredge_modbus/translations/de.json
+++ b/custom_components/solaredge_modbus/translations/de.json
@@ -15,7 +15,9 @@
           "read_meter_3": "Lese die Stände des Zähler 3 (nur für Modelle mit Zähler)",
           "read_battery_1": "Lese die Daten der Batterie 1 (nur für Modelle mit Batterie)",
           "read_battery_2": "Lese die Daten der Batterie 2 (nur für Modelle mit Batterie)",
-          "scan_interval": "Das Abfrageintervall der modbus Register in Sekunden"
+          "read_battery_3": "Lese die Daten der Batterie 3 (nur für Modelle mit Batterie)",
+          "scan_interval": "Das Abfrageintervall der modbus Register [s]"
+          "max_export_control_site_limit": "Das maximale Site-Limit für die Exportkontrolle [W]"
         }
       }
     },

--- a/custom_components/solaredge_modbus/translations/en.json
+++ b/custom_components/solaredge_modbus/translations/en.json
@@ -16,7 +16,8 @@
           "read_battery_1": "Read battery 1 data (only when equipped)",
           "read_battery_2": "Read battery 2 data (only when equipped)",
           "read_battery_3": "Read battery 3 data (only when equipped)",
-          "scan_interval": "The polling frequentie of the modbus registers in seconds"
+          "scan_interval": "The modbus registers polling interval [s]"
+          "max_export_control_site_limit": "The maximum export-control site-limit [W]"
         }
       }
     },

--- a/custom_components/solaredge_modbus/translations/nb.json
+++ b/custom_components/solaredge_modbus/translations/nb.json
@@ -15,7 +15,9 @@
           "read_meter_3": "Les måler 3-data (bare for målermodeller)",
           "read_battery_1": "Les batteri 1 data (bare når den er utstyrt)",
           "read_battery_2": "Les batteri 2 data (bare når den er utstyrt)",
-          "scan_interval": "Avstemningsfrekvensen til modbus registreres på få sekunder"
+          "read_battery_3": "Les batteri 3 data (bare når den er utstyrt)",
+          "scan_interval": "Modbussen registrerer pollingintervall [s]"
+          "max_export_control_site_limit": "Den maksimale grensen for eksportkontrollnettsted [W]"
         }
       }
     },

--- a/custom_components/solaredge_modbus/translations/nl.json
+++ b/custom_components/solaredge_modbus/translations/nl.json
@@ -15,7 +15,9 @@
           "read_meter_3": "Lees meter 3 data (enkel voor voor meter modellen)",
           "read_battery_1": "Lees accu 1 data (alleen indien uitgerust)",
           "read_battery_2": "Lees accu 2 data (alleen indien uitgerust)",
-          "scan_interval": "De polling-frequentie van de modbus registratie in seconden"
+          "read_battery_3": "Lees accu 3 data (alleen indien uitgerust)",
+          "scan_interval": "Het modbus registers ververs-interval [s]"
+          "max_export_control_site_limit": "De maximale locatielimiet voor exportcontrole [W]"
         }
       }
     },


### PR DESCRIPTION
I noticed that the last config-item has no header-string, adding this one, including translations.

Also some small fixes/improvements.