### PR TITLE
Change pymodbus requirement to soft pin

### DIFF
--- a/custom_components/solaredge_modbus/manifest.json
+++ b/custom_components/solaredge_modbus/manifest.json
@@ -2,7 +2,7 @@
   "domain": "solaredge_modbus",
   "name": "SolarEdge Modbus",
   "documentation": "https://github.com/binsentsu/home-assistant-solaredge-modbus",
-  "requirements": ["pymodbus==3.8.3"],
+  "requirements": ["pymodbus>=3.8.3"],
   "dependencies": [],
   "codeowners": ["@binsentsu"],
   "config_flow": true,


### PR DESCRIPTION
Hard pinning of python requirements is really not healthy for the ecosystem (see https://github.com/davidrapan/ha-solarman/issues/456 and https://github.com/home-assistant/core/issues/140446#issuecomment-2718212172).

Edit: And you are using soft pin [here](https://github.com/WillCodeForCats/solaredge-modbus-multi/blob/8e2812377b27abe8f78638bfe822d2fd400f1fad/custom_components/solaredge_modbus_multi/manifest.json) anyway.