### PR TITLE
284: pass payload as a single entry list instead

### DIFF
--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -297,7 +297,7 @@ class SolaredgeModbusHub(DataUpdateCoordinator):
         try:
             with self._lock:
                 return self._client.write_registers(
-                    address=address, values=payload, slave=unit
+                    address=address, values=[payload], slave=unit
                 )
         except ModbusException as err:
             raise HomeAssistantError(err) from err


### PR DESCRIPTION
See discussion here regarding the pymodbus move from 3.7.x to 3.8.x. Be aware though that even though the change appears to be backwards compatible according to the pymodbus api doc, I haven't explicitely tried it. Futhermore this change is barely tested it change the "Storage Remote Command Mode" around via the homeassistant UI, which did seem to do its job.