### PR TITLE
fix: gate read_modbus_data_meter3 on read_meter3

### DIFF
--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -1068,7 +1068,7 @@ class SolaredgeModbusCoordinator(DataUpdateCoordinator):
             )
             and (not self.read_meter1 or await self.hub.read_modbus_data_meter1())
             and (not self.read_meter2 or await self.hub.read_modbus_data_meter2())
-            and (not self.read_meter2 or await self.hub.read_modbus_data_meter3())
+            and (not self.read_meter3 or await self.hub.read_modbus_data_meter3())
             and await self.hub.read_modbus_data_storage(
                 self.has_battery, self.has_meter
             )


### PR DESCRIPTION
Closes #365. Line 1071 read meter 3 only when `read_meter2` was true (typo for `read_meter3`); with meter 3 enabled but not 2, the meter-3 update never fired.