### PR TITLE
Implement Reconfigure option in config-flow

### DIFF
--- a/custom_components/solaredge_modbus/config_flow.py
+++ b/custom_components/solaredge_modbus/config_flow.py
@@ -107,3 +107,64 @@ class SolaredgeModbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
         )
+
+    async def async_step_reconfigure(self, user_input=None):
+        """Handle reconfiguration of an existing entry.
+
+        Allows the user to change host, port, meter/battery settings,
+        scan interval and all other options without removing and
+        re-adding the integration.
+        """
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        current = entry.data
+
+        errors = {}
+
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+
+            # Allow same host (current entry) — only block a *different* host
+            # that is already used by another entry
+            other_hosts = {
+                e.data[CONF_HOST]
+                for e in self.hass.config_entries.async_entries(DOMAIN)
+                if e.entry_id != entry.entry_id
+            }
+            if host in other_hosts:
+                errors[CONF_HOST] = "already_configured"
+            elif not host_valid(host):
+                errors[CONF_HOST] = "invalid host IP"
+            else:
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data=user_input,
+                    reason="reconfigure_successful",
+                )
+
+        # Pre-fill the form with the current configuration
+        reconfigure_schema = vol.Schema(
+            {
+                vol.Optional(CONF_NAME, default=current.get(CONF_NAME, DEFAULT_NAME)): str,
+                vol.Required(CONF_HOST, default=current.get(CONF_HOST, "")): str,
+                vol.Required(CONF_PORT, default=current.get(CONF_PORT, DEFAULT_PORT)): int,
+                vol.Optional(CONF_MODBUS_ADDRESS, default=current.get(CONF_MODBUS_ADDRESS, DEFAULT_MODBUS_ADDRESS)): int,
+                vol.Optional(CONF_POWER_CONTROL, default=current.get(CONF_POWER_CONTROL, DEFAULT_POWER_CONTROL)): bool,
+                vol.Optional(CONF_READ_METER1, default=current.get(CONF_READ_METER1, DEFAULT_READ_METER1)): bool,
+                vol.Optional(CONF_READ_METER2, default=current.get(CONF_READ_METER2, DEFAULT_READ_METER2)): bool,
+                vol.Optional(CONF_READ_METER3, default=current.get(CONF_READ_METER3, DEFAULT_READ_METER3)): bool,
+                vol.Optional(CONF_READ_BATTERY1, default=current.get(CONF_READ_BATTERY1, DEFAULT_READ_BATTERY1)): bool,
+                vol.Optional(CONF_READ_BATTERY2, default=current.get(CONF_READ_BATTERY2, DEFAULT_READ_BATTERY2)): bool,
+                vol.Optional(CONF_READ_BATTERY3, default=current.get(CONF_READ_BATTERY3, DEFAULT_READ_BATTERY3)): bool,
+                vol.Optional(CONF_SCAN_INTERVAL, default=current.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)): int,
+                vol.Optional(
+                    CONF_MAX_EXPORT_CONTROL_SITE_LIMIT,
+                    default=current.get(CONF_MAX_EXPORT_CONTROL_SITE_LIMIT, DEFAULT_MAX_EXPORT_CONTROL_SITE_LIMIT),
+                ): int,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=reconfigure_schema,
+            errors=errors,
+        )

--- a/custom_components/solaredge_modbus/strings.json
+++ b/custom_components/solaredge_modbus/strings.json
@@ -19,13 +19,32 @@
           "scan_interval": "The modbus registers polling interval [s]",
           "max_export_control_site_limit": "The maximum export-control site-limit [W]"
         }
+      },
+      "reconfigure": {
+        "title": "Reconfigure your SolarEdge modbus connection",
+        "data": {
+          "host": "The ip-address of your Solaredge device",
+          "name": "The prefix to be used for your SolarEdge sensors",
+          "port": "The TCP port on which to connect to the SolarEdge",
+          "modbus_address": "The modbus address",
+          "power_control": "Enable setting active power limit",
+          "read_meter_1": "Read meter 1 data (only for meter models)",
+          "read_meter_2": "Read meter 2 data (only for meter models)",
+          "read_meter_3": "Read meter 3 data (only for meter models)",
+          "read_battery_1": "Read battery 1 data (only when equipped)",
+          "read_battery_2": "Read battery 2 data (only when equipped)",
+          "read_battery_3": "Read battery 3 data (only when equipped)",
+          "scan_interval": "The modbus registers polling interval [s]",
+          "max_export_control_site_limit": "The maximum export-control site-limit [W]"
+        }
       }
     },
     "error": {
       "already_configured": "Device is already configured"
     },
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "reconfigure_successful": "Configuration updated successfully."
     }
   }
 }

--- a/custom_components/solaredge_modbus/translations/de.json
+++ b/custom_components/solaredge_modbus/translations/de.json
@@ -8,7 +8,25 @@
           "host": "Die IP-Adresse des Solaredge Wechselrichters",
           "name": "Das Prefix, das für die SolarEdge Sensoren verwendet werden soll",
           "port": "Der TCP Port des SolarEdge Wechselrichters (z.B. 502)",
-		      "modbus_address": "Modbus-Adresse",
+          "modbus_address": "Modbus-Adresse",
+          "power_control": "Einstellung der Wirkleistungsbegrenzung aktivieren",
+          "read_meter_1": "Lese die Stände des Zähler 1 (nur für Modelle mit Zähler)",
+          "read_meter_2": "Lese die Stände des Zähler 2 (nur für Modelle mit Zähler)",
+          "read_meter_3": "Lese die Stände des Zähler 3 (nur für Modelle mit Zähler)",
+          "read_battery_1": "Lese die Daten der Batterie 1 (nur für Modelle mit Batterie)",
+          "read_battery_2": "Lese die Daten der Batterie 2 (nur für Modelle mit Batterie)",
+          "read_battery_3": "Lese die Daten der Batterie 3 (nur für Modelle mit Batterie)",
+          "scan_interval": "Das Abfrageintervall der modbus Register [s]",
+          "max_export_control_site_limit": "Das maximale Site-Limit für die Exportkontrolle [W]"
+        }
+      },
+      "reconfigure": {
+        "title": "SolarEdge Modbus-Verbindung neu konfigurieren",
+        "data": {
+          "host": "Die IP-Adresse des Solaredge Wechselrichters",
+          "name": "Das Prefix, das für die SolarEdge Sensoren verwendet werden soll",
+          "port": "Der TCP Port des SolarEdge Wechselrichters (z.B. 502)",
+          "modbus_address": "Modbus-Adresse",
           "power_control": "Einstellung der Wirkleistungsbegrenzung aktivieren",
           "read_meter_1": "Lese die Stände des Zähler 1 (nur für Modelle mit Zähler)",
           "read_meter_2": "Lese die Stände des Zähler 2 (nur für Modelle mit Zähler)",
@@ -25,7 +43,8 @@
       "already_configured": "Der Wechselrichter ist bereits konfiguriert.,"
     },
     "abort": {
-      "already_configured": "Der Wechselrichter ist bereits konfiguriert."
+      "already_configured": "Der Wechselrichter ist bereits konfiguriert.",
+      "reconfigure_successful": "Konfiguration erfolgreich aktualisiert."
     }
   }
 }

--- a/custom_components/solaredge_modbus/translations/en.json
+++ b/custom_components/solaredge_modbus/translations/en.json
@@ -8,7 +8,25 @@
           "host": "The ip-address of your Solaredge inverter",
           "name": "The prefix to be used for your SolarEdge sensors",
           "port": "The TCP port on which to connect to the SolarEdge inverter",
-		      "modbus_address": "The modbus address",
+          "modbus_address": "The modbus address",
+          "power_control": "Enable setting active power limit",
+          "read_meter_1": "Read meter 1 data (only for meter models)",
+          "read_meter_2": "Read meter 2 data (only for meter models)",
+          "read_meter_3": "Read meter 3 data (only for meter models)",
+          "read_battery_1": "Read battery 1 data (only when equipped)",
+          "read_battery_2": "Read battery 2 data (only when equipped)",
+          "read_battery_3": "Read battery 3 data (only when equipped)",
+          "scan_interval": "The modbus registers polling interval [s]",
+          "max_export_control_site_limit": "The maximum export-control site-limit [W]"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure your SolarEdge modbus connection",
+        "data": {
+          "host": "The ip-address of your Solaredge inverter",
+          "name": "The prefix to be used for your SolarEdge sensors",
+          "port": "The TCP port on which to connect to the SolarEdge inverter",
+          "modbus_address": "The modbus address",
           "power_control": "Enable setting active power limit",
           "read_meter_1": "Read meter 1 data (only for meter models)",
           "read_meter_2": "Read meter 2 data (only for meter models)",
@@ -25,7 +43,8 @@
       "already_configured": "Device is already configured"
     },
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "reconfigure_successful": "Configuration updated successfully."
     }
   }
 }

--- a/custom_components/solaredge_modbus/translations/it.json
+++ b/custom_components/solaredge_modbus/translations/it.json
@@ -19,13 +19,32 @@
           "scan_interval": "Il tempo di polling dei registri modbus [s]",
           "max_export_control_site_limit": "Limite massimo di potenza esportata [W]"
         }
+      },
+      "reconfigure": {
+        "title": "Riconfigura la connessione al tuo SolarEdge",
+        "data": {
+          "host": "L'indirizzo ip dell'inverter SolarEdge",
+          "name": "Il prefisso da usare per i sensori SolarEdge",
+          "port": "La porta TCP per connettersi all'inverter SolarEdge",
+          "modbus_address": "L'indirizzo modbus",
+          "power_control": "Abilita impostazione limite potenza attiva",
+          "read_meter_1": "Leggi dati meter 1 data (solo per modelli dotati di meter)",
+          "read_meter_2": "Leggi dati meter 2 data (solo per modelli dotati di meter)",
+          "read_meter_3": "Leggi dati meter 3 data (solo per modelli dotati di meter)",
+          "read_battery_1": "Leggi dati batteria 1 (solo quando presente)",
+          "read_battery_2": "Leggi dati batteria 2 (solo quando presente)",
+          "read_battery_3": "Leggi dati batteria 3 (solo quando presente)",
+          "scan_interval": "Il tempo di polling dei registri modbus [s]",
+          "max_export_control_site_limit": "Limite massimo di potenza esportata [W]"
+        }
       }
     },
     "error": {
       "already_configured": "Dispositivo già configurato"
     },
     "abort": {
-      "already_configured": "Dispositivo già configurato"
+      "already_configured": "Dispositivo già configurato",
+      "reconfigure_successful": "Configurazione aggiornata con successo."
     }
   }
 }

--- a/custom_components/solaredge_modbus/translations/nb.json
+++ b/custom_components/solaredge_modbus/translations/nb.json
@@ -8,7 +8,25 @@
           "host": "IP-adressen til din Solaredge-omformer",
           "name": "Prefikset som skal brukes til SolarEdge-sensorene dine",
           "port": "TCP-porten som skal kobles til SolarEdge-omformeren",
-		      "modbus_address": "Modbus adresse",
+          "modbus_address": "Modbus adresse",
+          "power_control": "Aktiver innstilling av aktiv effektgrense",
+          "read_meter_1": "Les måler 1-data (bare for målermodeller)",
+          "read_meter_2": "Les måler 2-data (bare for målermodeller)",
+          "read_meter_3": "Les måler 3-data (bare for målermodeller)",
+          "read_battery_1": "Les batteri 1 data (bare når den er utstyrt)",
+          "read_battery_2": "Les batteri 2 data (bare når den er utstyrt)",
+          "read_battery_3": "Les batteri 3 data (bare når den er utstyrt)",
+          "scan_interval": "Modbussen registrerer pollingintervall [s]",
+          "max_export_control_site_limit": "Den maksimale grensen for eksportkontrollnettsted [W]"
+        }
+      },
+      "reconfigure": {
+        "title": "Rekonfigurer din SolarEdge modbus-tilkobling",
+        "data": {
+          "host": "IP-adressen til din Solaredge-omformer",
+          "name": "Prefikset som skal brukes til SolarEdge-sensorene dine",
+          "port": "TCP-porten som skal kobles til SolarEdge-omformeren",
+          "modbus_address": "Modbus adresse",
           "power_control": "Aktiver innstilling av aktiv effektgrense",
           "read_meter_1": "Les måler 1-data (bare for målermodeller)",
           "read_meter_2": "Les måler 2-data (bare for målermodeller)",
@@ -25,7 +43,8 @@
       "already_configured": "Enheten er allerede konfigurert"
     },
     "abort": {
-      "already_configured": "Enheten er allerede konfigurert"
+      "already_configured": "Enheten er allerede konfigurert",
+      "reconfigure_successful": "Konfigurasjonen ble oppdatert."
     }
   }
 }

--- a/custom_components/solaredge_modbus/translations/nl.json
+++ b/custom_components/solaredge_modbus/translations/nl.json
@@ -8,7 +8,25 @@
           "host": "Het ip-adres van uw Solaredge-omvormer",
           "name": "Het voorvoegsel dat moet worden gebruikt voor uw SolarEdge-sensoren",
           "port": "De TCP-poort waarop verbinding moet worden gemaakt met de SolarEdge-omvormer",
-		      "modbus_address": "Modbus adres",
+          "modbus_address": "Modbus adres",
+          "power_control": "Activeer het instellen van de limiet voor het actieve vermogen",
+          "read_meter_1": "Lees meter 1 data (enkel voor voor meter modellen)",
+          "read_meter_2": "Lees meter 2 data (enkel voor voor meter modellen)",
+          "read_meter_3": "Lees meter 3 data (enkel voor voor meter modellen)",
+          "read_battery_1": "Lees accu 1 data (alleen indien uitgerust)",
+          "read_battery_2": "Lees accu 2 data (alleen indien uitgerust)",
+          "read_battery_3": "Lees accu 3 data (alleen indien uitgerust)",
+          "scan_interval": "Het modbus registers ververs-interval [s]",
+          "max_export_control_site_limit": "De maximale locatielimiet voor exportcontrole [W]"
+        }
+      },
+      "reconfigure": {
+        "title": "Herconfigureer uw SolarEdge modbus-verbinding",
+        "data": {
+          "host": "Het ip-adres van uw Solaredge-omvormer",
+          "name": "Het voorvoegsel dat moet worden gebruikt voor uw SolarEdge-sensoren",
+          "port": "De TCP-poort waarop verbinding moet worden gemaakt met de SolarEdge-omvormer",
+          "modbus_address": "Modbus adres",
           "power_control": "Activeer het instellen van de limiet voor het actieve vermogen",
           "read_meter_1": "Lees meter 1 data (enkel voor voor meter modellen)",
           "read_meter_2": "Lees meter 2 data (enkel voor voor meter modellen)",
@@ -25,7 +43,8 @@
       "already_configured": "Apparaat is al geconfigureerd"
     },
     "abort": {
-      "already_configured": "Apparaat is al geconfigureerd"
+      "already_configured": "Apparaat is al geconfigureerd",
+      "reconfigure_successful": "Configuratie succesvol bijgewerkt."
     }
   }
 }


### PR DESCRIPTION
# Feature: Reconfigure Support
 
## Summary
 
This PR adds support for reconfiguring an existing SolarEdge Modbus integration
entry via **Settings → Devices & Services → SolarEdge Modbus → ⋮ → Reconfigure**,
without having to delete and re-add the integration.

<img width="1033" height="430" alt="grafik" src="https://github.com/user-attachments/assets/20440e05-3e02-4522-b8df-18a156cff630" />

<img width="542" height="1140" alt="grafik" src="https://github.com/user-attachments/assets/e41da520-e6d1-45fc-9026-4c612b47b947" />

## Motivation
 
Previously, changing any setting (host, port, meter/battery configuration, scan
interval, etc.) required removing the integration entirely and setting it up from
scratch. This caused all associated entities and their history to be lost.
 
A common workaround was to edit the integration's entry directly in the Home
Assistant `.storage` registry files — a fragile and error-prone manual process.
 
## Changes
 
### `config_flow.py`
 
Added `async_step_reconfigure` to `SolaredgeModbusConfigFlow`:
 
- The reconfigure form is **pre-filled** with the current configuration, so the
  user only needs to change what is actually different
- Host validation correctly allows the same host as the current entry while
  still blocking hosts already used by other entries
- On save, `async_update_reload_and_abort` updates the entry, reloads the
  integration, and closes the dialog in a single step
### Translations
 
Added `reconfigure` step and `reconfigure_successful` abort string to all
supported languages:
 
- `en.json`
- `de.json`
- `nl.json`
- `nb.json`
- `it.json`
- `strings.json`

## Behavior
 
| Scenario | Before | After |
|---|---|---|
| Change host or port | Delete + re-add | Reconfigure |
| Enable/disable meter or battery | Delete + re-add | Reconfigure |
| Change scan interval | Delete + re-add | Reconfigure |
 
## Compatibility
 
- Fully backwards compatible — existing entries and the initial setup flow are
  unchanged
- No changes to data schema or entry version
